### PR TITLE
add log location, make commands for gatekeep chip agnostic

### DIFF
--- a/Casks/circleci-runner.rb
+++ b/Casks/circleci-runner.rb
@@ -115,14 +115,16 @@ Config: #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml
 Documentation: https://circleci.com/docs/runner-overview/
 CircleCI Self-Hosted Runner Changelog: https://circleci.com/changelog/self-hosted-runner/
 Before Running:
-  To check application notarization run `$ spctl -a -vvv -t install /opt/homebrew/bin/circleci-runner`
+  To check application notarization run `$ spctl -a -vvv -t install \"$(homebrew --prefix)/bin/circleci-runner\"`
 
-  To accept the notarization headlessly run `$ sudo xattr -r -d com.apple.quarantine /opt/homebrew/bin/circleci-runner`
+  To accept the notarization headlessly run `$ sudo xattr -r -d com.apple.quarantine \"$(homebrew --prefix)/bin/circleci-runner\"`
 
   Update the configration with your self-hosted runner token and runner name before starting
 
   Enable and Start the CircleCI Runner LaunchAgent with `$ launchctl load #{Dir.home}/Library/LaunchAgents/com.circleci.runner.plist`
-  Start CircleCI Runner manually with `$ circleci-runner machine --config #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml`"
+  Start CircleCI Runner manually with `$ circleci-runner machine --config #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml`
+  View the CircleCI Runner logs at #{Dir.home}/Library/Logs/com.circleci.runner/runner.log"
+  
   end
 
   zap trash:[

--- a/README.md
+++ b/README.md
@@ -35,15 +35,23 @@ To programmatically check and authorize the self-hosted runner use the following
 
 Verify the signature and notarization of the binary
 
-`$ spctl -a -vvv -t install /opt/homebrew/bin/circleci-runner`
+`$ spctl -a -vvv -t install "$(brew --prefix)/bin/circleci-runner"`
 
 Accept the Apple notarization ticket
 
-`$ sudo xattr -r -d com.apple.quarantine /opt/homebrew/bin/circleci-runner`
+`$ sudo xattr -r -d com.apple.quarantine "$(brew --prefix)/bin/circleci-runner"`
 
 #### Stopping and Restarting the Self-Hosted Runner
 
 The runner is automatically started as a MacOS Launch Agent for the [launchd](https://en.wikipedia.org/wiki/Launchd) service manager. This is configured in the Library of the installing user at `$HOME/Library/LaunchAgents/com.circleci.runner.plist`. It is managed via the `launchctl` command.
+
+To stop the self-hosted runner
+
+`$ sudo launchctl unload $HOME/Library/LaunchAgents/com.circleci.runner.plist`
+
+To start the self-hosted runner
+
+`$ sudo launchctl load $HOME/Library/LaunchAgents/com.circleci.runner.plist`
 
 #### Uninstallation
 
@@ -52,6 +60,10 @@ To uninstall the Self-Hosted CircleCI Runner brew package **without** purging lo
 
 To uninstall the Self-Hosted CircleCI Runner **with** purging logs and configuration:
 `brew uninstall --cask --zap circleci-public/homebrew-circleci/circleci-runner`
+
+## Logs
+
+Logs for the self-hosted runner can be found at `$HOME/Library/Logs/com.circleci.runner/runner.log`
 
 ## Contributing
 


### PR DESCRIPTION
Update the README and caveats to be chipset agnostic, add more info about where to find logs and manage the circleci-runner process. 