### PR TITLE
Add @circleci-internal-runner-bot as a code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,4 @@
 * @CircleCI-Public/on-prem
 
+# @circleci-internal-runner-bot requires co-ownership so it can approve release PRs automatically
+/Casks/circleci-runner.rb @CircleCI-Public/on-prem @circleci-internal-runner-bot


### PR DESCRIPTION
This should address this issue: https://github.com/CircleCI-Public/homebrew-circleci/pull/65

I tried adding the https://github.com/orgs/CircleCI-Public/teams/on-prem-bots team as a code owner, but it was failing validation: https://github.com/CircleCI-Public/homebrew-circleci/commit/dd98ad7831484c8f3a262360a82ac9f6824ef858