### PR TITLE
fix: Unload & reload plist

### DIFF
--- a/Casks/circleci-runner.rb
+++ b/Casks/circleci-runner.rb
@@ -126,7 +126,7 @@ Before Running:
 
   Update the configration with your self-hosted runner token and runner name before starting
 
-  Enable and Start the CircleCI Runner LaunchAgent with `$ launchctl load #{Dir.home}/Library/LaunchAgents/com.circleci.runner.plist`
+  Enable and Start the CircleCI Runner LaunchAgent with `$ PLIST=#{Dir.home}/Library/LaunchAgents/com.circleci.runner.plist launchctl load $PLIST || (launchctl unload $PLIST && launchctl load $PLIST)`
   Start CircleCI Runner manually with `$ circleci-runner machine --config #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml`
   View the CircleCI Runner logs at #{Dir.home}/Library/Logs/com.circleci.runner/runner.log"
   


### PR DESCRIPTION
In the event the initial loading of the plist fails, we should have the user unload it and reload it. If it still fails to start there is a genuine problem.