### PR TITLE
Update instances of `File.exists?` to `File.exist?` [ONPREM-1205]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ jobs:
           name: Install New Updated Package
           command: |
             brew install --build-from-source Casks/circleci-runner.rb 2> err.out || echo "possible cask method error on install"
+            cat err.out
             # build from source doesn't recognize the cask method with homebrew update
             # this checks that the error out was indeed the unefined method and the circleci runner binary was installed
             if [[ "$?" -eq "1" ]]; then 
@@ -38,6 +39,7 @@ jobs:
               which circleci-runner
               echo "CircleCI Runner Formula successfully installed"
             fi
+          
             sed -i circleci-runner.rb.bk "s/\[\[RESOURCE_CLASS_TOKEN\]\]/$CI_RUNNER_TOKEN/g" ~/Library/Preferences/com.circleci.runner/config.yaml
             sed -i circleci-runner.rb.bk "s/\[\[RUNNER_NAME\]\]/CI-Brew-Package-Test/g" ~/Library/Preferences/com.circleci.runner/config.yaml
       - run:

--- a/Casks/circleci-runner.rb
+++ b/Casks/circleci-runner.rb
@@ -37,7 +37,7 @@ cask "circleci-runner" do
       end
     end
 
-    if not File.exists?(plistFile)
+    if not File.exist?(plistFile)
       plist = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
 <!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
 <plist version=\"1.0\">
@@ -100,7 +100,7 @@ cask "circleci-runner" do
 
 
   postflight do
-    if not File.exists?(configFile)
+    if not File.exist?(configFile)
       conf = "runner:
   name: [[RUNNER_NAME]]
   working_directory: \"#{workingDir}\"


### PR DESCRIPTION
The former has been deprecated for some time but is now fully removed

**Testing**

Before: https://app.circleci.com/pipelines/github/CircleCI-Public/homebrew-circleci/326/workflows/6a639fe1-c5dc-463d-8250-1cc984e3eac5/jobs/327?invite=true#step-102-95099_100

After: https://app.circleci.com/pipelines/github/CircleCI-Public/homebrew-circleci/331/workflows/72efa19d-e755-45ea-b3c8-2cfbfbd669c2/jobs/332