### PR TITLE
add versioned formulas

### DIFF
--- a/Casks/circleci-runner@3.0.12.rb
+++ b/Casks/circleci-runner@3.0.12.rb
@@ -1,0 +1,138 @@
+cask "circleci-runner" do
+  version "3.0.11"
+  name "circleci-runner"
+  desc "The self-hosted runner agent for CircleCI"
+  homepage "https://circleci.com/docs/2.0/runner-overview/"
+
+  intelSHA = "144abf3e347ec47c3c87aa0122a50a9e07abc7056bd6d152c9e309c69b1e92ef"
+  armSHA = "97ac9103946aaad1897528e8ceffe484d7092e3aedf55026d3f2d29413e185a7"
+  
+  if Hardware::CPU.intel? 
+    sha256 "#{intelSHA}"
+    url "https://circleci-binary-releases.s3.amazonaws.com/circleci-runner/#{version}/circleci-runner_darwin_amd64.tar.gz"
+    binary "circleci-runner"
+  else
+    sha256 "#{armSHA}"
+    url "https://circleci-binary-releases.s3.amazonaws.com/circleci-runner/#{version}/circleci-runner_darwin_arm64.tar.gz"
+    binary "circleci-runner"
+  end
+
+  configDir = "#{Dir.home}/Library/Preferences/com.circleci.runner"
+  configFile = "#{configDir}/config.yaml"
+  workingDir = "#{Dir.home}/Library/com.circleci.runner/workdir"
+  launchAgentDir = "#{Dir.home}/Library/LaunchAgents"
+  plistFile = "#{launchAgentDir}/com.circleci.runner.plist"
+  logDir = "#{Dir.home}/Library/Logs/com.circleci.runner"
+  logFile = "#{logDir}/runner.log"
+
+
+  postflight do
+    if not File.exists?(configDir)
+    system_command "mkdir", 
+      args: ["-p", "#{configDir}"]
+    end
+
+    if not File.exists?(configFile)
+      conf = "runner:
+  name: [[RUNNER_NAME]]
+  working_directory: \"#{workingDir}\"
+  cleanup_working_directory: true
+api:
+  auth_token: [[RESOURCE_CLASS_TOKEN]]"
+
+      File.open(configFile, "w"){|f| f.write "#{conf}"}
+    end
+
+    if not File.exists?(workingDir)
+      system_command "mkdir",
+        args: ["-p", workingDir]
+    end
+
+    # launchD configuartion
+    if not File.exists?(launchAgentDir)
+      system_command "mkdir",
+        args: ["-p", launchAgentDir]
+    end
+
+    if not File.exists?(plistFile)
+      plist = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+    <dict>
+        <key>Label</key>
+        <string>com.circleci.runner</string>
+
+        <key>Program</key>
+        <string>/opt/homebrew/bin/circleci-runner</string>
+
+        <key>ProgramArguments</key>
+        <array>
+            <string>/opt/homebrew/bin/circleci-runner</string>
+            <string>machine</string>
+            <string>--config</string>
+            <string>#{configFile}</string>
+        </array>
+
+        <key>RunAtLoad</key>
+        <true/>
+
+        <!-- The agent needs to run at all times -->
+        <key>KeepAlive</key>
+        <true/>
+
+        <!-- This prevents macOS from limiting the resource usage of the agent -->
+        <key>ProcessType</key>
+        <string>Interactive</string>
+
+        <!-- Increase the frequency of restarting the agent on failure, or post-update -->
+        <key>ThrottleInterval</key>
+        <integer>3</integer>
+
+        <!-- Wait for 10 minutes for the agent to shut down (the agent itself waits for tasks to complete) -->
+        <key>ExitTimeOut</key>
+        <integer>600</integer>
+
+        <key>StandardOutPath</key>
+        <string>#{logFile}</string>
+        <key>StandardErrorPath</key>
+        <string>#{logFile}</string>
+    </dict>
+</plist>"
+
+    File.open(plistFile, "w"){|f|f.write "#{plist}"}
+    end
+
+    if not File.exists?(logDir)
+      system_command "mkdir",
+        args: ["-p", logDir]
+    end
+
+  end
+
+  def caveats;  
+    "Logs: #{Dir.home}/Library/Logs/com.circleci.runner
+Config: #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml
+Documentation: https://circleci.com/docs/runner-overview/
+CircleCI Self-Hosted Runner Changelog: https://circleci.com/changelog/self-hosted-runner/
+Before Running:
+  To check application notarization run `$ spctl -a -vvv -t install /opt/homebrew/bin/circleci-runner`
+
+  To accept the notarization headlessly run `$ sudo xattr -r -d com.apple.quarantine /opt/homebrew/bin/circleci-runner`
+
+  Update the configration with your self-hosted runner token and runner name before starting
+
+  Enable and Start the CircleCI Runner LaunchAgent with `$ launchctl load #{Dir.home}/Library/LaunchAgents/com.circleci.runner.plist`
+  Start CircleCI Runner manually with `$ circleci-runner machine --config #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml`"
+  end
+
+  zap trash:[
+    "#{configDir}/*",
+    "#{configDir}",
+    "#{plistFile}",
+    "#{logDir}/*",
+    "#{logDir}",
+    "#{workingDir}/*",
+  ]
+
+  uninstall launchctl: "com.circleci.runner"
+end

--- a/Casks/circleci-runner@3.0.13.rb
+++ b/Casks/circleci-runner@3.0.13.rb
@@ -1,0 +1,138 @@
+cask "circleci-runner" do
+  version "3.0.12"
+  name "circleci-runner"
+  desc "The self-hosted runner agent for CircleCI"
+  homepage "https://circleci.com/docs/2.0/runner-overview/"
+
+  intelSHA = "a3c85153d8b15f39e5e481e86f4d8ddcf60055188f8e37981782b55fb1f95fba"
+  armSHA = "37d4b198aa95feadc27a23ef1d01c61de610d04917bcaf0044a7b5bf1fe39de7"
+  
+  if Hardware::CPU.intel? 
+    sha256 "#{intelSHA}"
+    url "https://circleci-binary-releases.s3.amazonaws.com/circleci-runner/#{version}/circleci-runner_darwin_amd64.tar.gz"
+    binary "circleci-runner"
+  else
+    sha256 "#{armSHA}"
+    url "https://circleci-binary-releases.s3.amazonaws.com/circleci-runner/#{version}/circleci-runner_darwin_arm64.tar.gz"
+    binary "circleci-runner"
+  end
+
+  configDir = "#{Dir.home}/Library/Preferences/com.circleci.runner"
+  configFile = "#{configDir}/config.yaml"
+  workingDir = "#{Dir.home}/Library/com.circleci.runner/workdir"
+  launchAgentDir = "#{Dir.home}/Library/LaunchAgents"
+  plistFile = "#{launchAgentDir}/com.circleci.runner.plist"
+  logDir = "#{Dir.home}/Library/Logs/com.circleci.runner"
+  logFile = "#{logDir}/runner.log"
+
+
+  postflight do
+    if not File.exists?(configDir)
+    system_command "mkdir", 
+      args: ["-p", "#{configDir}"]
+    end
+
+    if not File.exists?(configFile)
+      conf = "runner:
+  name: [[RUNNER_NAME]]
+  working_directory: \"#{workingDir}\"
+  cleanup_working_directory: true
+api:
+  auth_token: [[RESOURCE_CLASS_TOKEN]]"
+
+      File.open(configFile, "w"){|f| f.write "#{conf}"}
+    end
+
+    if not File.exists?(workingDir)
+      system_command "mkdir",
+        args: ["-p", workingDir]
+    end
+
+    # launchD configuartion
+    if not File.exists?(launchAgentDir)
+      system_command "mkdir",
+        args: ["-p", launchAgentDir]
+    end
+
+    if not File.exists?(plistFile)
+      plist = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+    <dict>
+        <key>Label</key>
+        <string>com.circleci.runner</string>
+
+        <key>Program</key>
+        <string>/opt/homebrew/bin/circleci-runner</string>
+
+        <key>ProgramArguments</key>
+        <array>
+            <string>/opt/homebrew/bin/circleci-runner</string>
+            <string>machine</string>
+            <string>--config</string>
+            <string>#{configFile}</string>
+        </array>
+
+        <key>RunAtLoad</key>
+        <true/>
+
+        <!-- The agent needs to run at all times -->
+        <key>KeepAlive</key>
+        <true/>
+
+        <!-- This prevents macOS from limiting the resource usage of the agent -->
+        <key>ProcessType</key>
+        <string>Interactive</string>
+
+        <!-- Increase the frequency of restarting the agent on failure, or post-update -->
+        <key>ThrottleInterval</key>
+        <integer>3</integer>
+
+        <!-- Wait for 10 minutes for the agent to shut down (the agent itself waits for tasks to complete) -->
+        <key>ExitTimeOut</key>
+        <integer>600</integer>
+
+        <key>StandardOutPath</key>
+        <string>#{logFile}</string>
+        <key>StandardErrorPath</key>
+        <string>#{logFile}</string>
+    </dict>
+</plist>"
+
+    File.open(plistFile, "w"){|f|f.write "#{plist}"}
+    end
+
+    if not File.exists?(logDir)
+      system_command "mkdir",
+        args: ["-p", logDir]
+    end
+
+  end
+
+  def caveats;  
+    "Logs: #{Dir.home}/Library/Logs/com.circleci.runner
+Config: #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml
+Documentation: https://circleci.com/docs/runner-overview/
+CircleCI Self-Hosted Runner Changelog: https://circleci.com/changelog/self-hosted-runner/
+Before Running:
+  To check application notarization run `$ spctl -a -vvv -t install /opt/homebrew/bin/circleci-runner`
+
+  To accept the notarization headlessly run `$ sudo xattr -r -d com.apple.quarantine /opt/homebrew/bin/circleci-runner`
+
+  Update the configration with your self-hosted runner token and runner name before starting
+
+  Enable and Start the CircleCI Runner LaunchAgent with `$ launchctl load #{Dir.home}/Library/LaunchAgents/com.circleci.runner.plist`
+  Start CircleCI Runner manually with `$ circleci-runner machine --config #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml`"
+  end
+
+  zap trash:[
+    "#{configDir}/*",
+    "#{configDir}",
+    "#{plistFile}",
+    "#{logDir}/*",
+    "#{logDir}",
+    "#{workingDir}/*",
+  ]
+
+  uninstall launchctl: "com.circleci.runner"
+end

--- a/Casks/circleci-runner@3.0.15.rb
+++ b/Casks/circleci-runner@3.0.15.rb
@@ -1,0 +1,157 @@
+cask "circleci-runner" do
+  version "3.0.15"
+  name "circleci-runner"
+  desc "The self-hosted runner agent for CircleCI"
+  homepage "https://circleci.com/docs/2.0/runner-overview/"
+
+  intelSHA = "51d952491d74d8ca735b8886a553b1d6dd4600539ea09fb8d72238c7dedb0384"
+  armSHA = "00768920f6830ef6dec00eb50f744892c683d1549d4ad7927433d8b5737007a6"
+  
+  if Hardware::CPU.intel? 
+    sha256 "#{intelSHA}"
+    url "https://circleci-binary-releases.s3.amazonaws.com/circleci-runner/#{version}/circleci-runner_darwin_amd64.tar.gz"
+    binary "circleci-runner"
+  else
+    sha256 "#{armSHA}"
+    url "https://circleci-binary-releases.s3.amazonaws.com/circleci-runner/#{version}/circleci-runner_darwin_arm64.tar.gz"
+    binary "circleci-runner"
+  end
+
+  configDir = "#{Dir.home}/Library/Preferences/com.circleci.runner"
+  configFile = "#{configDir}/config.yaml"
+  workingDir = "#{Dir.home}/Library/com.circleci.runner/workdir"
+  launchAgentDir = "#{Dir.home}/Library/LaunchAgents"
+  plistFile = "#{launchAgentDir}/com.circleci.runner.plist"
+  logDir = "#{Dir.home}/Library/Logs/com.circleci.runner"
+  logFile = "#{logDir}/runner.log"
+
+  prefix = ENV["HOMEBREW_PREFIX"]
+  service "#{Dir.home}/Library/LaunchAgents/com.circleci.runner.plist"
+
+  preflight do
+    if not File.exists?(plistFile)
+      plist = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+    <dict>
+        <key>Label</key>
+        <string>com.circleci.runner</string>
+
+        <key>Program</key>
+        <string>#{prefix}/bin/circleci-runner</string>
+
+        <key>ProgramArguments</key>
+        <array>
+            <string>#{prefix}/bin/circleci-runner</string>
+            <string>machine</string>
+            <string>--config</string>
+            <string>#{configFile}</string>
+        </array>
+
+        <key>RunAtLoad</key>
+        <true/>
+
+        	<key>LimitLoadToSessionType</key>
+	       <array>
+            <!-- start agent during GUI sessions -->
+	         <string>Aqua</string>
+            <!-- start agent during ssh sessions -->
+	         <string>StandardIO</string>
+	         <string>Background</string>
+	       </array>
+
+        <!-- The agent needs to run at all times -->
+        <key>KeepAlive</key>
+        <true/>
+
+        <!-- This prevents macOS from limiting the resource usage of the agent -->
+        <key>ProcessType</key>
+        <string>Interactive</string>
+
+        <!-- Increase the frequency of restarting the agent on failure, or post-update -->
+        <key>ThrottleInterval</key>
+        <integer>3</integer>
+
+        <!-- Wait for 10 minutes for the agent to shut down (the agent itself waits for tasks to complete) -->
+        <key>ExitTimeOut</key>
+        <integer>600</integer>
+
+        <key>StandardOutPath</key>
+        <string>#{logFile}</string>
+        <key>StandardErrorPath</key>
+        <string>#{logFile}</string>
+    </dict>
+</plist>"
+
+    File.open(plistFile, "w"){|f|f.write "#{plist}"}
+    
+    end
+  end
+
+
+  postflight do
+    if not File.exists?(configDir)
+    system_command "mkdir", 
+      args: ["-p", "#{configDir}"]
+    end
+
+    if not File.exists?(configFile)
+      conf = "runner:
+  name: [[RUNNER_NAME]]
+  working_directory: \"#{workingDir}\"
+  cleanup_working_directory: true
+api:
+  auth_token: [[RESOURCE_CLASS_TOKEN]]"
+
+      File.open(configFile, "w"){|f| f.write "#{conf}"}
+    end
+
+    if not File.exists?(workingDir)
+      system_command "mkdir",
+        args: ["-p", workingDir]
+    end
+
+    # launchD configuartion
+    if not File.exists?(launchAgentDir)
+      system_command "mkdir",
+        args: ["-p", launchAgentDir]
+    end
+
+
+    if not File.exists?(logDir)
+      system_command "mkdir",
+        args: ["-p", logDir]
+    end
+
+  end
+
+
+  def caveats;  
+    "Logs: #{Dir.home}/Library/Logs/com.circleci.runner
+Config: #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml
+Documentation: https://circleci.com/docs/runner-overview/
+CircleCI Self-Hosted Runner Changelog: https://circleci.com/changelog/self-hosted-runner/
+Before Running:
+  To check application notarization run `$ spctl -a -vvv -t install \"$(brew --prefix)/bin/circleci-runner\"`
+
+  To accept the notarization headlessly run `$ sudo xattr -r -d com.apple.quarantine \"$(brew --prefix)/bin/circleci-runner\"`
+
+  Update the configration with your self-hosted runner token and runner name before starting
+
+  Enable and Start the CircleCI Runner LaunchAgent with `$ launchctl load #{Dir.home}/Library/LaunchAgents/com.circleci.runner.plist`
+  Start CircleCI Runner manually with `$ circleci-runner machine --config #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml`
+  View the CircleCI Runner logs at #{Dir.home}/Library/Logs/com.circleci.runner/runner.log"
+  
+  end
+
+  zap trash:[
+    "#{configDir}/*",
+    "#{configDir}",
+    "#{plistFile}",
+    "#{logDir}/*",
+    "#{logDir}",
+    "#{workingDir}/*",
+  ]
+
+  uninstall launchctl: "com.circleci.runner"
+end

--- a/Casks/circleci-runner@3.0.16.rb
+++ b/Casks/circleci-runner@3.0.16.rb
@@ -1,0 +1,157 @@
+cask "circleci-runner" do
+  version "3.0.16"
+  name "circleci-runner"
+  desc "The self-hosted runner agent for CircleCI"
+  homepage "https://circleci.com/docs/2.0/runner-overview/"
+
+  intelSHA = "77e5841d5037449e2ca2347ae3c03ae8d4033b2b42187980d3e2172740fa0866"
+  armSHA = "16710a3c97c00d32e84fa38d703cb5979c771d9364089fa514a72beb93c1a0fe"
+  
+  if Hardware::CPU.intel? 
+    sha256 "#{intelSHA}"
+    url "https://circleci-binary-releases.s3.amazonaws.com/circleci-runner/#{version}/circleci-runner_darwin_amd64.tar.gz"
+    binary "circleci-runner"
+  else
+    sha256 "#{armSHA}"
+    url "https://circleci-binary-releases.s3.amazonaws.com/circleci-runner/#{version}/circleci-runner_darwin_arm64.tar.gz"
+    binary "circleci-runner"
+  end
+
+  configDir = "#{Dir.home}/Library/Preferences/com.circleci.runner"
+  configFile = "#{configDir}/config.yaml"
+  workingDir = "#{Dir.home}/Library/com.circleci.runner/workdir"
+  launchAgentDir = "#{Dir.home}/Library/LaunchAgents"
+  plistFile = "#{launchAgentDir}/com.circleci.runner.plist"
+  logDir = "#{Dir.home}/Library/Logs/com.circleci.runner"
+  logFile = "#{logDir}/runner.log"
+
+  prefix = ENV["HOMEBREW_PREFIX"]
+  service "#{Dir.home}/Library/LaunchAgents/com.circleci.runner.plist"
+
+  preflight do
+    if not File.exists?(plistFile)
+      plist = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+    <dict>
+        <key>Label</key>
+        <string>com.circleci.runner</string>
+
+        <key>Program</key>
+        <string>#{prefix}/bin/circleci-runner</string>
+
+        <key>ProgramArguments</key>
+        <array>
+            <string>#{prefix}/bin/circleci-runner</string>
+            <string>machine</string>
+            <string>--config</string>
+            <string>#{configFile}</string>
+        </array>
+
+        <key>RunAtLoad</key>
+        <true/>
+
+        	<key>LimitLoadToSessionType</key>
+	       <array>
+            <!-- start agent during GUI sessions -->
+	         <string>Aqua</string>
+            <!-- start agent during ssh sessions -->
+	         <string>StandardIO</string>
+	         <string>Background</string>
+	       </array>
+
+        <!-- The agent needs to run at all times -->
+        <key>KeepAlive</key>
+        <true/>
+
+        <!-- This prevents macOS from limiting the resource usage of the agent -->
+        <key>ProcessType</key>
+        <string>Interactive</string>
+
+        <!-- Increase the frequency of restarting the agent on failure, or post-update -->
+        <key>ThrottleInterval</key>
+        <integer>3</integer>
+
+        <!-- Wait for 10 minutes for the agent to shut down (the agent itself waits for tasks to complete) -->
+        <key>ExitTimeOut</key>
+        <integer>600</integer>
+
+        <key>StandardOutPath</key>
+        <string>#{logFile}</string>
+        <key>StandardErrorPath</key>
+        <string>#{logFile}</string>
+    </dict>
+</plist>"
+
+    File.open(plistFile, "w"){|f|f.write "#{plist}"}
+    
+    end
+  end
+
+
+  postflight do
+    if not File.exists?(configDir)
+    system_command "mkdir", 
+      args: ["-p", "#{configDir}"]
+    end
+
+    if not File.exists?(configFile)
+      conf = "runner:
+  name: [[RUNNER_NAME]]
+  working_directory: \"#{workingDir}\"
+  cleanup_working_directory: true
+api:
+  auth_token: [[RESOURCE_CLASS_TOKEN]]"
+
+      File.open(configFile, "w"){|f| f.write "#{conf}"}
+    end
+
+    if not File.exists?(workingDir)
+      system_command "mkdir",
+        args: ["-p", workingDir]
+    end
+
+    # launchD configuartion
+    if not File.exists?(launchAgentDir)
+      system_command "mkdir",
+        args: ["-p", launchAgentDir]
+    end
+
+
+    if not File.exists?(logDir)
+      system_command "mkdir",
+        args: ["-p", logDir]
+    end
+
+  end
+
+
+  def caveats;  
+    "Logs: #{Dir.home}/Library/Logs/com.circleci.runner
+Config: #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml
+Documentation: https://circleci.com/docs/runner-overview/
+CircleCI Self-Hosted Runner Changelog: https://circleci.com/changelog/self-hosted-runner/
+Before Running:
+  To check application notarization run `$ spctl -a -vvv -t install \"$(brew --prefix)/bin/circleci-runner\"`
+
+  To accept the notarization headlessly run `$ sudo xattr -r -d com.apple.quarantine \"$(brew --prefix)/bin/circleci-runner\"`
+
+  Update the configration with your self-hosted runner token and runner name before starting
+
+  Enable and Start the CircleCI Runner LaunchAgent with `$ launchctl load #{Dir.home}/Library/LaunchAgents/com.circleci.runner.plist`
+  Start CircleCI Runner manually with `$ circleci-runner machine --config #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml`
+  View the CircleCI Runner logs at #{Dir.home}/Library/Logs/com.circleci.runner/runner.log"
+  
+  end
+
+  zap trash:[
+    "#{configDir}/*",
+    "#{configDir}",
+    "#{plistFile}",
+    "#{logDir}/*",
+    "#{logDir}",
+    "#{workingDir}/*",
+  ]
+
+  uninstall launchctl: "com.circleci.runner"
+end

--- a/Casks/circleci-runner@3.0.17.rb
+++ b/Casks/circleci-runner@3.0.17.rb
@@ -1,0 +1,157 @@
+cask "circleci-runner" do
+  version "3.0.17"
+  name "circleci-runner"
+  desc "The self-hosted runner agent for CircleCI"
+  homepage "https://circleci.com/docs/2.0/runner-overview/"
+
+  intelSHA = "fe68197cd90472194b65f1954ab377b8c08f2875135284c8c1f29595b9d1ebbf"
+  armSHA = "84b50e2e24b424fbeac8d06fdb111023abab82cb51b3f1f7761e6a0e7928c316"
+  
+  if Hardware::CPU.intel? 
+    sha256 "#{intelSHA}"
+    url "https://circleci-binary-releases.s3.amazonaws.com/circleci-runner/#{version}/circleci-runner_darwin_amd64.tar.gz"
+    binary "circleci-runner"
+  else
+    sha256 "#{armSHA}"
+    url "https://circleci-binary-releases.s3.amazonaws.com/circleci-runner/#{version}/circleci-runner_darwin_arm64.tar.gz"
+    binary "circleci-runner"
+  end
+
+  configDir = "#{Dir.home}/Library/Preferences/com.circleci.runner"
+  configFile = "#{configDir}/config.yaml"
+  workingDir = "#{Dir.home}/Library/com.circleci.runner/workdir"
+  launchAgentDir = "#{Dir.home}/Library/LaunchAgents"
+  plistFile = "#{launchAgentDir}/com.circleci.runner.plist"
+  logDir = "#{Dir.home}/Library/Logs/com.circleci.runner"
+  logFile = "#{logDir}/runner.log"
+
+  prefix = ENV["HOMEBREW_PREFIX"]
+  service "#{Dir.home}/Library/LaunchAgents/com.circleci.runner.plist"
+
+  preflight do
+    if not File.exists?(plistFile)
+      plist = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+    <dict>
+        <key>Label</key>
+        <string>com.circleci.runner</string>
+
+        <key>Program</key>
+        <string>#{prefix}/bin/circleci-runner</string>
+
+        <key>ProgramArguments</key>
+        <array>
+            <string>#{prefix}/bin/circleci-runner</string>
+            <string>machine</string>
+            <string>--config</string>
+            <string>#{configFile}</string>
+        </array>
+
+        <key>RunAtLoad</key>
+        <true/>
+
+        	<key>LimitLoadToSessionType</key>
+	       <array>
+            <!-- start agent during GUI sessions -->
+	         <string>Aqua</string>
+            <!-- start agent during ssh sessions -->
+	         <string>StandardIO</string>
+	         <string>Background</string>
+	       </array>
+
+        <!-- The agent needs to run at all times -->
+        <key>KeepAlive</key>
+        <true/>
+
+        <!-- This prevents macOS from limiting the resource usage of the agent -->
+        <key>ProcessType</key>
+        <string>Interactive</string>
+
+        <!-- Increase the frequency of restarting the agent on failure, or post-update -->
+        <key>ThrottleInterval</key>
+        <integer>3</integer>
+
+        <!-- Wait for 10 minutes for the agent to shut down (the agent itself waits for tasks to complete) -->
+        <key>ExitTimeOut</key>
+        <integer>600</integer>
+
+        <key>StandardOutPath</key>
+        <string>#{logFile}</string>
+        <key>StandardErrorPath</key>
+        <string>#{logFile}</string>
+    </dict>
+</plist>"
+
+    File.open(plistFile, "w"){|f|f.write "#{plist}"}
+    
+    end
+  end
+
+
+  postflight do
+    if not File.exists?(configDir)
+    system_command "mkdir", 
+      args: ["-p", "#{configDir}"]
+    end
+
+    if not File.exists?(configFile)
+      conf = "runner:
+  name: [[RUNNER_NAME]]
+  working_directory: \"#{workingDir}\"
+  cleanup_working_directory: true
+api:
+  auth_token: [[RESOURCE_CLASS_TOKEN]]"
+
+      File.open(configFile, "w"){|f| f.write "#{conf}"}
+    end
+
+    if not File.exists?(workingDir)
+      system_command "mkdir",
+        args: ["-p", workingDir]
+    end
+
+    # launchD configuartion
+    if not File.exists?(launchAgentDir)
+      system_command "mkdir",
+        args: ["-p", launchAgentDir]
+    end
+
+
+    if not File.exists?(logDir)
+      system_command "mkdir",
+        args: ["-p", logDir]
+    end
+
+  end
+
+
+  def caveats;  
+    "Logs: #{Dir.home}/Library/Logs/com.circleci.runner
+Config: #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml
+Documentation: https://circleci.com/docs/runner-overview/
+CircleCI Self-Hosted Runner Changelog: https://circleci.com/changelog/self-hosted-runner/
+Before Running:
+  To check application notarization run `$ spctl -a -vvv -t install \"$(brew --prefix)/bin/circleci-runner\"`
+
+  To accept the notarization headlessly run `$ sudo xattr -r -d com.apple.quarantine \"$(brew --prefix)/bin/circleci-runner\"`
+
+  Update the configration with your self-hosted runner token and runner name before starting
+
+  Enable and Start the CircleCI Runner LaunchAgent with `$ launchctl load #{Dir.home}/Library/LaunchAgents/com.circleci.runner.plist`
+  Start CircleCI Runner manually with `$ circleci-runner machine --config #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml`
+  View the CircleCI Runner logs at #{Dir.home}/Library/Logs/com.circleci.runner/runner.log"
+  
+  end
+
+  zap trash:[
+    "#{configDir}/*",
+    "#{configDir}",
+    "#{plistFile}",
+    "#{logDir}/*",
+    "#{logDir}",
+    "#{workingDir}/*",
+  ]
+
+  uninstall launchctl: "com.circleci.runner"
+end

--- a/Casks/circleci-runner@3.0.18.rb
+++ b/Casks/circleci-runner@3.0.18.rb
@@ -1,0 +1,157 @@
+cask "circleci-runner" do
+  version "3.0.18"
+  name "circleci-runner"
+  desc "The self-hosted runner agent for CircleCI"
+  homepage "https://circleci.com/docs/2.0/runner-overview/"
+
+  intelSHA = "f9557442acce9b41303064b43884f9250201b79744ed6275ab7db844f9b6dfd9"
+  armSHA = "d2807ca0de5db0278fcefa05dc64b4bd6e06286609ad3d6731a5abe78803666d"
+  
+  if Hardware::CPU.intel? 
+    sha256 "#{intelSHA}"
+    url "https://circleci-binary-releases.s3.amazonaws.com/circleci-runner/#{version}/circleci-runner_darwin_amd64.tar.gz"
+    binary "circleci-runner"
+  else
+    sha256 "#{armSHA}"
+    url "https://circleci-binary-releases.s3.amazonaws.com/circleci-runner/#{version}/circleci-runner_darwin_arm64.tar.gz"
+    binary "circleci-runner"
+  end
+
+  configDir = "#{Dir.home}/Library/Preferences/com.circleci.runner"
+  configFile = "#{configDir}/config.yaml"
+  workingDir = "#{Dir.home}/Library/com.circleci.runner/workdir"
+  launchAgentDir = "#{Dir.home}/Library/LaunchAgents"
+  plistFile = "#{launchAgentDir}/com.circleci.runner.plist"
+  logDir = "#{Dir.home}/Library/Logs/com.circleci.runner"
+  logFile = "#{logDir}/runner.log"
+
+  prefix = ENV["HOMEBREW_PREFIX"]
+  service "#{Dir.home}/Library/LaunchAgents/com.circleci.runner.plist"
+
+  preflight do
+    if not File.exists?(plistFile)
+      plist = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+    <dict>
+        <key>Label</key>
+        <string>com.circleci.runner</string>
+
+        <key>Program</key>
+        <string>#{prefix}/bin/circleci-runner</string>
+
+        <key>ProgramArguments</key>
+        <array>
+            <string>#{prefix}/bin/circleci-runner</string>
+            <string>machine</string>
+            <string>--config</string>
+            <string>#{configFile}</string>
+        </array>
+
+        <key>RunAtLoad</key>
+        <true/>
+
+        	<key>LimitLoadToSessionType</key>
+	       <array>
+            <!-- start agent during GUI sessions -->
+	         <string>Aqua</string>
+            <!-- start agent during ssh sessions -->
+	         <string>StandardIO</string>
+	         <string>Background</string>
+	       </array>
+
+        <!-- The agent needs to run at all times -->
+        <key>KeepAlive</key>
+        <true/>
+
+        <!-- This prevents macOS from limiting the resource usage of the agent -->
+        <key>ProcessType</key>
+        <string>Interactive</string>
+
+        <!-- Increase the frequency of restarting the agent on failure, or post-update -->
+        <key>ThrottleInterval</key>
+        <integer>3</integer>
+
+        <!-- Wait for 10 minutes for the agent to shut down (the agent itself waits for tasks to complete) -->
+        <key>ExitTimeOut</key>
+        <integer>600</integer>
+
+        <key>StandardOutPath</key>
+        <string>#{logFile}</string>
+        <key>StandardErrorPath</key>
+        <string>#{logFile}</string>
+    </dict>
+</plist>"
+
+    File.open(plistFile, "w"){|f|f.write "#{plist}"}
+    
+    end
+  end
+
+
+  postflight do
+    if not File.exists?(configDir)
+    system_command "mkdir", 
+      args: ["-p", "#{configDir}"]
+    end
+
+    if not File.exists?(configFile)
+      conf = "runner:
+  name: [[RUNNER_NAME]]
+  working_directory: \"#{workingDir}\"
+  cleanup_working_directory: true
+api:
+  auth_token: [[RESOURCE_CLASS_TOKEN]]"
+
+      File.open(configFile, "w"){|f| f.write "#{conf}"}
+    end
+
+    if not File.exists?(workingDir)
+      system_command "mkdir",
+        args: ["-p", workingDir]
+    end
+
+    # launchD configuartion
+    if not File.exists?(launchAgentDir)
+      system_command "mkdir",
+        args: ["-p", launchAgentDir]
+    end
+
+
+    if not File.exists?(logDir)
+      system_command "mkdir",
+        args: ["-p", logDir]
+    end
+
+  end
+
+
+  def caveats;  
+    "Logs: #{Dir.home}/Library/Logs/com.circleci.runner
+Config: #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml
+Documentation: https://circleci.com/docs/runner-overview/
+CircleCI Self-Hosted Runner Changelog: https://circleci.com/changelog/self-hosted-runner/
+Before Running:
+  To check application notarization run `$ spctl -a -vvv -t install \"$(brew --prefix)/bin/circleci-runner\"`
+
+  To accept the notarization headlessly run `$ sudo xattr -r -d com.apple.quarantine \"$(brew --prefix)/bin/circleci-runner\"`
+
+  Update the configration with your self-hosted runner token and runner name before starting
+
+  Enable and Start the CircleCI Runner LaunchAgent with `$ launchctl load #{Dir.home}/Library/LaunchAgents/com.circleci.runner.plist`
+  Start CircleCI Runner manually with `$ circleci-runner machine --config #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml`
+  View the CircleCI Runner logs at #{Dir.home}/Library/Logs/com.circleci.runner/runner.log"
+  
+  end
+
+  zap trash:[
+    "#{configDir}/*",
+    "#{configDir}",
+    "#{plistFile}",
+    "#{logDir}/*",
+    "#{logDir}",
+    "#{workingDir}/*",
+  ]
+
+  uninstall launchctl: "com.circleci.runner"
+end

--- a/Casks/circleci-runner@3.0.19.rb
+++ b/Casks/circleci-runner@3.0.19.rb
@@ -1,0 +1,143 @@
+cask "circleci-runner" do
+  version "3.0.19"
+  name "circleci-runner"
+  desc "The self-hosted runner agent for CircleCI"
+  homepage "https://circleci.com/docs/2.0/runner-overview/"
+
+  intelSHA = "b6aa07736d44b9cd377c97da842d9a3b94a66d8ba4cfade6f829cde44b8b7907"
+  armSHA = "6d89cfae6903173b2b1e512c7716d288456579b60967aae0f7ca76f0a4bf5b3f"
+  
+  if Hardware::CPU.intel? 
+    sha256 "#{intelSHA}"
+    url "https://circleci-binary-releases.s3.amazonaws.com/circleci-runner/#{version}/circleci-runner_darwin_amd64.tar.gz"
+    binary "circleci-runner"
+  else
+    sha256 "#{armSHA}"
+    url "https://circleci-binary-releases.s3.amazonaws.com/circleci-runner/#{version}/circleci-runner_darwin_arm64.tar.gz"
+    binary "circleci-runner"
+  end
+
+  configDir = "#{Dir.home}/Library/Preferences/com.circleci.runner"
+  configFile = "#{configDir}/config.yaml"
+  workingDir = "#{Dir.home}/Library/com.circleci.runner/workdir"
+  launchAgentDir = "#{Dir.home}/Library/LaunchAgents"
+  plistFile = "#{launchAgentDir}/com.circleci.runner.plist"
+  logDir = "#{Dir.home}/Library/Logs/com.circleci.runner"
+  logFile = "#{logDir}/runner.log"
+
+  prefix = ENV["HOMEBREW_PREFIX"]
+  service "#{Dir.home}/Library/LaunchAgents/com.circleci.runner.plist"
+
+  preflight do
+    # Create the necessary directories prior to installation
+    dirs = [configDir, launchAgentDir, logDir, workingDir]
+    dirs.each do |dir|
+      if not File.exist?(dir)
+        system_command 'mkdir', args: ['-p', dir]
+      end
+    end
+
+    if not File.exists?(plistFile)
+      plist = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+    <dict>
+        <key>Label</key>
+        <string>com.circleci.runner</string>
+
+        <key>Program</key>
+        <string>#{prefix}/bin/circleci-runner</string>
+
+        <key>ProgramArguments</key>
+        <array>
+            <string>#{prefix}/bin/circleci-runner</string>
+            <string>machine</string>
+            <string>--config</string>
+            <string>#{configFile}</string>
+        </array>
+
+        <key>RunAtLoad</key>
+        <true/>
+
+        	<key>LimitLoadToSessionType</key>
+	       <array>
+            <!-- start agent during GUI sessions -->
+	         <string>Aqua</string>
+            <!-- start agent during ssh sessions -->
+	         <string>StandardIO</string>
+	         <string>Background</string>
+	       </array>
+
+        <!-- The agent needs to run at all times -->
+        <key>KeepAlive</key>
+        <true/>
+
+        <!-- This prevents macOS from limiting the resource usage of the agent -->
+        <key>ProcessType</key>
+        <string>Interactive</string>
+
+        <!-- Increase the frequency of restarting the agent on failure, or post-update -->
+        <key>ThrottleInterval</key>
+        <integer>3</integer>
+
+        <!-- Wait for 10 minutes for the agent to shut down (the agent itself waits for tasks to complete) -->
+        <key>ExitTimeOut</key>
+        <integer>600</integer>
+
+        <key>StandardOutPath</key>
+        <string>#{logFile}</string>
+        <key>StandardErrorPath</key>
+        <string>#{logFile}</string>
+    </dict>
+</plist>"
+
+    File.open(plistFile, "w"){|f|f.write "#{plist}"}
+    
+    end
+  end
+
+
+  postflight do
+    if not File.exists?(configFile)
+      conf = "runner:
+  name: [[RUNNER_NAME]]
+  working_directory: \"#{workingDir}\"
+  cleanup_working_directory: true
+api:
+  auth_token: [[RESOURCE_CLASS_TOKEN]]"
+
+      File.open(configFile, "w"){|f| f.write "#{conf}"}
+    end
+
+  end
+
+
+  def caveats;  
+    "Logs: #{Dir.home}/Library/Logs/com.circleci.runner
+Config: #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml
+Documentation: https://circleci.com/docs/runner-overview/
+CircleCI Self-Hosted Runner Changelog: https://circleci.com/changelog/self-hosted-runner/
+Before Running:
+  To check application notarization run `$ spctl -a -vvv -t install \"$(brew --prefix)/bin/circleci-runner\"`
+
+  To accept the notarization headlessly run `$ sudo xattr -r -d com.apple.quarantine \"$(brew --prefix)/bin/circleci-runner\"`
+
+  Update the configration with your self-hosted runner token and runner name before starting
+
+  Enable and Start the CircleCI Runner LaunchAgent with `$ launchctl load #{Dir.home}/Library/LaunchAgents/com.circleci.runner.plist`
+  Start CircleCI Runner manually with `$ circleci-runner machine --config #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml`
+  View the CircleCI Runner logs at #{Dir.home}/Library/Logs/com.circleci.runner/runner.log"
+  
+  end
+
+  zap trash:[
+    "#{configDir}/*",
+    "#{configDir}",
+    "#{plistFile}",
+    "#{logDir}/*",
+    "#{logDir}",
+    "#{workingDir}/*",
+  ]
+
+  uninstall launchctl: "com.circleci.runner"
+end

--- a/Casks/circleci-runner@3.0.20.rb
+++ b/Casks/circleci-runner@3.0.20.rb
@@ -1,0 +1,143 @@
+cask "circleci-runner" do
+  version "3.0.20"
+  name "circleci-runner"
+  desc "The self-hosted runner agent for CircleCI"
+  homepage "https://circleci.com/docs/2.0/runner-overview/"
+
+  intelSHA = "de4e4767446d671dc4b96b525a5e05f145f92dd5b646609f1e76bba04ca3e0cf"
+  armSHA = "4210d42479c5bd3ba57c5644575049f6fbe6c7de3e4a3ecbe2271044aeaf5184"
+  
+  if Hardware::CPU.intel? 
+    sha256 "#{intelSHA}"
+    url "https://circleci-binary-releases.s3.amazonaws.com/circleci-runner/#{version}/circleci-runner_darwin_amd64.tar.gz"
+    binary "circleci-runner"
+  else
+    sha256 "#{armSHA}"
+    url "https://circleci-binary-releases.s3.amazonaws.com/circleci-runner/#{version}/circleci-runner_darwin_arm64.tar.gz"
+    binary "circleci-runner"
+  end
+
+  configDir = "#{Dir.home}/Library/Preferences/com.circleci.runner"
+  configFile = "#{configDir}/config.yaml"
+  workingDir = "#{Dir.home}/Library/com.circleci.runner/workdir"
+  launchAgentDir = "#{Dir.home}/Library/LaunchAgents"
+  plistFile = "#{launchAgentDir}/com.circleci.runner.plist"
+  logDir = "#{Dir.home}/Library/Logs/com.circleci.runner"
+  logFile = "#{logDir}/runner.log"
+
+  prefix = ENV["HOMEBREW_PREFIX"]
+  service "#{Dir.home}/Library/LaunchAgents/com.circleci.runner.plist"
+
+  preflight do
+    # Create the necessary directories prior to installation
+    dirs = [configDir, launchAgentDir, logDir, workingDir]
+    dirs.each do |dir|
+      if not File.exist?(dir)
+        system_command 'mkdir', args: ['-p', dir]
+      end
+    end
+
+    if not File.exists?(plistFile)
+      plist = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+    <dict>
+        <key>Label</key>
+        <string>com.circleci.runner</string>
+
+        <key>Program</key>
+        <string>#{prefix}/bin/circleci-runner</string>
+
+        <key>ProgramArguments</key>
+        <array>
+            <string>#{prefix}/bin/circleci-runner</string>
+            <string>machine</string>
+            <string>--config</string>
+            <string>#{configFile}</string>
+        </array>
+
+        <key>RunAtLoad</key>
+        <true/>
+
+        	<key>LimitLoadToSessionType</key>
+	       <array>
+            <!-- start agent during GUI sessions -->
+	         <string>Aqua</string>
+            <!-- start agent during ssh sessions -->
+	         <string>StandardIO</string>
+	         <string>Background</string>
+	       </array>
+
+        <!-- The agent needs to run at all times -->
+        <key>KeepAlive</key>
+        <true/>
+
+        <!-- This prevents macOS from limiting the resource usage of the agent -->
+        <key>ProcessType</key>
+        <string>Interactive</string>
+
+        <!-- Increase the frequency of restarting the agent on failure, or post-update -->
+        <key>ThrottleInterval</key>
+        <integer>3</integer>
+
+        <!-- Wait for 10 minutes for the agent to shut down (the agent itself waits for tasks to complete) -->
+        <key>ExitTimeOut</key>
+        <integer>600</integer>
+
+        <key>StandardOutPath</key>
+        <string>#{logFile}</string>
+        <key>StandardErrorPath</key>
+        <string>#{logFile}</string>
+    </dict>
+</plist>"
+
+    File.open(plistFile, "w"){|f|f.write "#{plist}"}
+    
+    end
+  end
+
+
+  postflight do
+    if not File.exists?(configFile)
+      conf = "runner:
+  name: [[RUNNER_NAME]]
+  working_directory: \"#{workingDir}\"
+  cleanup_working_directory: true
+api:
+  auth_token: [[RESOURCE_CLASS_TOKEN]]"
+
+      File.open(configFile, "w"){|f| f.write "#{conf}"}
+    end
+
+  end
+
+
+  def caveats;  
+    "Logs: #{Dir.home}/Library/Logs/com.circleci.runner
+Config: #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml
+Documentation: https://circleci.com/docs/runner-overview/
+CircleCI Self-Hosted Runner Changelog: https://circleci.com/changelog/self-hosted-runner/
+Before Running:
+  To check application notarization run `$ spctl -a -vvv -t install \"$(brew --prefix)/bin/circleci-runner\"`
+
+  To accept the notarization headlessly run `$ sudo xattr -r -d com.apple.quarantine \"$(brew --prefix)/bin/circleci-runner\"`
+
+  Update the configration with your self-hosted runner token and runner name before starting
+
+  Enable and Start the CircleCI Runner LaunchAgent with `$ launchctl load #{Dir.home}/Library/LaunchAgents/com.circleci.runner.plist`
+  Start CircleCI Runner manually with `$ circleci-runner machine --config #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml`
+  View the CircleCI Runner logs at #{Dir.home}/Library/Logs/com.circleci.runner/runner.log"
+  
+  end
+
+  zap trash:[
+    "#{configDir}/*",
+    "#{configDir}",
+    "#{plistFile}",
+    "#{logDir}/*",
+    "#{logDir}",
+    "#{workingDir}/*",
+  ]
+
+  uninstall launchctl: "com.circleci.runner"
+end

--- a/Casks/circleci-runner@3.0.21.rb
+++ b/Casks/circleci-runner@3.0.21.rb
@@ -1,0 +1,143 @@
+cask "circleci-runner" do
+  version "3.0.21"
+  name "circleci-runner"
+  desc "The self-hosted runner agent for CircleCI"
+  homepage "https://circleci.com/docs/2.0/runner-overview/"
+
+  intelSHA = "42ea0f837d9bd749add988d5db9bfe5bbf671fd8c85fc34d7e22d08490ddfee7"
+  armSHA = "7e1f4d52b023cd1a37fe19d81fd275c68ab86a65bb00cb77e2b1784db60b35d5"
+  
+  if Hardware::CPU.intel? 
+    sha256 "#{intelSHA}"
+    url "https://circleci-binary-releases.s3.amazonaws.com/circleci-runner/#{version}/circleci-runner_darwin_amd64.tar.gz"
+    binary "circleci-runner"
+  else
+    sha256 "#{armSHA}"
+    url "https://circleci-binary-releases.s3.amazonaws.com/circleci-runner/#{version}/circleci-runner_darwin_arm64.tar.gz"
+    binary "circleci-runner"
+  end
+
+  configDir = "#{Dir.home}/Library/Preferences/com.circleci.runner"
+  configFile = "#{configDir}/config.yaml"
+  workingDir = "#{Dir.home}/Library/com.circleci.runner/workdir"
+  launchAgentDir = "#{Dir.home}/Library/LaunchAgents"
+  plistFile = "#{launchAgentDir}/com.circleci.runner.plist"
+  logDir = "#{Dir.home}/Library/Logs/com.circleci.runner"
+  logFile = "#{logDir}/runner.log"
+
+  prefix = ENV["HOMEBREW_PREFIX"]
+  service "#{Dir.home}/Library/LaunchAgents/com.circleci.runner.plist"
+
+  preflight do
+    # Create the necessary directories prior to installation
+    dirs = [configDir, launchAgentDir, logDir, workingDir]
+    dirs.each do |dir|
+      if not File.exist?(dir)
+        system_command 'mkdir', args: ['-p', dir]
+      end
+    end
+
+    if not File.exists?(plistFile)
+      plist = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+    <dict>
+        <key>Label</key>
+        <string>com.circleci.runner</string>
+
+        <key>Program</key>
+        <string>#{prefix}/bin/circleci-runner</string>
+
+        <key>ProgramArguments</key>
+        <array>
+            <string>#{prefix}/bin/circleci-runner</string>
+            <string>machine</string>
+            <string>--config</string>
+            <string>#{configFile}</string>
+        </array>
+
+        <key>RunAtLoad</key>
+        <true/>
+
+        	<key>LimitLoadToSessionType</key>
+	       <array>
+            <!-- start agent during GUI sessions -->
+	         <string>Aqua</string>
+            <!-- start agent during ssh sessions -->
+	         <string>StandardIO</string>
+	         <string>Background</string>
+	       </array>
+
+        <!-- The agent needs to run at all times -->
+        <key>KeepAlive</key>
+        <true/>
+
+        <!-- This prevents macOS from limiting the resource usage of the agent -->
+        <key>ProcessType</key>
+        <string>Interactive</string>
+
+        <!-- Increase the frequency of restarting the agent on failure, or post-update -->
+        <key>ThrottleInterval</key>
+        <integer>3</integer>
+
+        <!-- Wait for 10 minutes for the agent to shut down (the agent itself waits for tasks to complete) -->
+        <key>ExitTimeOut</key>
+        <integer>600</integer>
+
+        <key>StandardOutPath</key>
+        <string>#{logFile}</string>
+        <key>StandardErrorPath</key>
+        <string>#{logFile}</string>
+    </dict>
+</plist>"
+
+    File.open(plistFile, "w"){|f|f.write "#{plist}"}
+    
+    end
+  end
+
+
+  postflight do
+    if not File.exists?(configFile)
+      conf = "runner:
+  name: [[RUNNER_NAME]]
+  working_directory: \"#{workingDir}\"
+  cleanup_working_directory: true
+api:
+  auth_token: [[RESOURCE_CLASS_TOKEN]]"
+
+      File.open(configFile, "w"){|f| f.write "#{conf}"}
+    end
+
+  end
+
+
+  def caveats;  
+    "Logs: #{Dir.home}/Library/Logs/com.circleci.runner
+Config: #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml
+Documentation: https://circleci.com/docs/runner-overview/
+CircleCI Self-Hosted Runner Changelog: https://circleci.com/changelog/self-hosted-runner/
+Before Running:
+  To check application notarization run `$ spctl -a -vvv -t install \"$(brew --prefix)/bin/circleci-runner\"`
+
+  To accept the notarization headlessly run `$ sudo xattr -r -d com.apple.quarantine \"$(brew --prefix)/bin/circleci-runner\"`
+
+  Update the configration with your self-hosted runner token and runner name before starting
+
+  Enable and Start the CircleCI Runner LaunchAgent with `$ launchctl load #{Dir.home}/Library/LaunchAgents/com.circleci.runner.plist`
+  Start CircleCI Runner manually with `$ circleci-runner machine --config #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml`
+  View the CircleCI Runner logs at #{Dir.home}/Library/Logs/com.circleci.runner/runner.log"
+  
+  end
+
+  zap trash:[
+    "#{configDir}/*",
+    "#{configDir}",
+    "#{plistFile}",
+    "#{logDir}/*",
+    "#{logDir}",
+    "#{workingDir}/*",
+  ]
+
+  uninstall launchctl: "com.circleci.runner"
+end

--- a/Casks/circleci-runner@3.0.22.rb
+++ b/Casks/circleci-runner@3.0.22.rb
@@ -1,0 +1,145 @@
+cask "circleci-runner" do
+  version "3.0.22"
+  name "circleci-runner"
+  desc "The self-hosted runner agent for CircleCI"
+  homepage "https://circleci.com/docs/2.0/runner-overview/"
+
+  intelSHA = "514c889cc547cf9be63524855b65b68d360bdbf0830985902484a3a8f3b2ee67"
+  armSHA = "9015afc88e263357d9dc5aaa2ef76894db550dbf39a18b15bc43cbe5e65cadb5"
+  
+  if Hardware::CPU.intel? 
+    sha256 "#{intelSHA}"
+    url "https://circleci-binary-releases.s3.amazonaws.com/circleci-runner/#{version}/circleci-runner_darwin_amd64.tar.gz"
+    binary "circleci-runner"
+  else
+    sha256 "#{armSHA}"
+    url "https://circleci-binary-releases.s3.amazonaws.com/circleci-runner/#{version}/circleci-runner_darwin_arm64.tar.gz"
+    binary "circleci-runner"
+  end
+
+  configDir = "#{Dir.home}/Library/Preferences/com.circleci.runner"
+  configFile = "#{configDir}/config.yaml"
+  workingDir = "#{Dir.home}/Library/com.circleci.runner/workdir"
+  launchAgentDir = "#{Dir.home}/Library/LaunchAgents"
+  plistFile = "#{launchAgentDir}/com.circleci.runner.plist"
+  logDir = "#{Dir.home}/Library/Logs/com.circleci.runner"
+  logFile = "#{logDir}/runner.log"
+
+  prefix = ENV["HOMEBREW_PREFIX"]
+  service "#{Dir.home}/Library/LaunchAgents/com.circleci.runner.plist"
+
+  preflight do
+    # Create the necessary directories prior to installation
+    dirs = [configDir, launchAgentDir, logDir, workingDir]
+    dirs.each do |dir|
+      if not File.exist?(dir)
+        system_command 'mkdir', args: ['-p', dir]
+      end
+    end
+
+    if not File.exist?(plistFile)
+      plist = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+    <dict>
+        <key>Label</key>
+        <string>com.circleci.runner</string>
+
+        <key>Program</key>
+        <string>#{prefix}/bin/circleci-runner</string>
+
+        <key>ProgramArguments</key>
+        <array>
+            <string>#{prefix}/bin/circleci-runner</string>
+            <string>machine</string>
+            <string>--config</string>
+            <string>#{configFile}</string>
+        </array>
+
+        <key>RunAtLoad</key>
+        <true/>
+
+        	<key>LimitLoadToSessionType</key>
+	       <array>
+            <!-- start agent during GUI sessions -->
+	         <string>Aqua</string>
+            <!-- start agent during ssh sessions -->
+	         <string>StandardIO</string>
+	         <string>Background</string>
+            <!-- start agent during standard user sessions -->
+	         <string>user</string>
+	       </array>
+
+        <!-- The agent needs to run at all times -->
+        <key>KeepAlive</key>
+        <true/>
+
+        <!-- This prevents macOS from limiting the resource usage of the agent -->
+        <key>ProcessType</key>
+        <string>Interactive</string>
+
+        <!-- Increase the frequency of restarting the agent on failure, or post-update -->
+        <key>ThrottleInterval</key>
+        <integer>3</integer>
+
+        <!-- Wait for 10 minutes for the agent to shut down (the agent itself waits for tasks to complete) -->
+        <key>ExitTimeOut</key>
+        <integer>600</integer>
+
+        <key>StandardOutPath</key>
+        <string>#{logFile}</string>
+        <key>StandardErrorPath</key>
+        <string>#{logFile}</string>
+    </dict>
+</plist>"
+
+    File.open(plistFile, "w"){|f|f.write "#{plist}"}
+    
+    end
+  end
+
+
+  postflight do
+    if not File.exist?(configFile)
+      conf = "runner:
+  name: [[RUNNER_NAME]]
+  working_directory: \"#{workingDir}\"
+  cleanup_working_directory: true
+api:
+  auth_token: [[RESOURCE_CLASS_TOKEN]]"
+
+      File.open(configFile, "w"){|f| f.write "#{conf}"}
+    end
+
+  end
+
+
+  def caveats;  
+    "Logs: #{Dir.home}/Library/Logs/com.circleci.runner
+Config: #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml
+Documentation: https://circleci.com/docs/runner-overview/
+CircleCI Self-Hosted Runner Changelog: https://circleci.com/changelog/self-hosted-runner/
+Before Running:
+  To check application notarization run `$ spctl -a -vvv -t install \"$(brew --prefix)/bin/circleci-runner\"`
+
+  To accept the notarization headlessly run `$ sudo xattr -r -d com.apple.quarantine \"$(brew --prefix)/bin/circleci-runner\"`
+
+  Update the configration with your self-hosted runner token and runner name before starting
+
+  Enable and Start the CircleCI Runner LaunchAgent with `$ PLIST=#{Dir.home}/Library/LaunchAgents/com.circleci.runner.plist launchctl load $PLIST || (launchctl unload $PLIST && launchctl load $PLIST)`
+  Start CircleCI Runner manually with `$ circleci-runner machine --config #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml`
+  View the CircleCI Runner logs at #{Dir.home}/Library/Logs/com.circleci.runner/runner.log"
+  
+  end
+
+  zap trash:[
+    "#{configDir}/*",
+    "#{configDir}",
+    "#{plistFile}",
+    "#{logDir}/*",
+    "#{logDir}",
+    "#{workingDir}/*",
+  ]
+
+  uninstall launchctl: "com.circleci.runner"
+end

--- a/Casks/circleci-runner@3.0.23.rb
+++ b/Casks/circleci-runner@3.0.23.rb
@@ -1,0 +1,145 @@
+cask "circleci-runner" do
+  version "3.0.23"
+  name "circleci-runner"
+  desc "The self-hosted runner agent for CircleCI"
+  homepage "https://circleci.com/docs/2.0/runner-overview/"
+
+  intelSHA = "895d45feb02e49a451c061b03d4eb79160a1bc281160c4b7c4fbde06f4a2a72a"
+  armSHA = "9c49f52f6535a9d78ec2f99602e7349043c0d275f5a0a6ab7e759fb8fe805cb3"
+  
+  if Hardware::CPU.intel? 
+    sha256 "#{intelSHA}"
+    url "https://circleci-binary-releases.s3.amazonaws.com/circleci-runner/#{version}/circleci-runner_darwin_amd64.tar.gz"
+    binary "circleci-runner"
+  else
+    sha256 "#{armSHA}"
+    url "https://circleci-binary-releases.s3.amazonaws.com/circleci-runner/#{version}/circleci-runner_darwin_arm64.tar.gz"
+    binary "circleci-runner"
+  end
+
+  configDir = "#{Dir.home}/Library/Preferences/com.circleci.runner"
+  configFile = "#{configDir}/config.yaml"
+  workingDir = "#{Dir.home}/Library/com.circleci.runner/workdir"
+  launchAgentDir = "#{Dir.home}/Library/LaunchAgents"
+  plistFile = "#{launchAgentDir}/com.circleci.runner.plist"
+  logDir = "#{Dir.home}/Library/Logs/com.circleci.runner"
+  logFile = "#{logDir}/runner.log"
+
+  prefix = ENV["HOMEBREW_PREFIX"]
+  service "#{Dir.home}/Library/LaunchAgents/com.circleci.runner.plist"
+
+  preflight do
+    # Create the necessary directories prior to installation
+    dirs = [configDir, launchAgentDir, logDir, workingDir]
+    dirs.each do |dir|
+      if not File.exist?(dir)
+        system_command 'mkdir', args: ['-p', dir]
+      end
+    end
+
+    if not File.exist?(plistFile)
+      plist = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+    <dict>
+        <key>Label</key>
+        <string>com.circleci.runner</string>
+
+        <key>Program</key>
+        <string>#{prefix}/bin/circleci-runner</string>
+
+        <key>ProgramArguments</key>
+        <array>
+            <string>#{prefix}/bin/circleci-runner</string>
+            <string>machine</string>
+            <string>--config</string>
+            <string>#{configFile}</string>
+        </array>
+
+        <key>RunAtLoad</key>
+        <true/>
+
+        	<key>LimitLoadToSessionType</key>
+	       <array>
+            <!-- start agent during GUI sessions -->
+	         <string>Aqua</string>
+            <!-- start agent during ssh sessions -->
+	         <string>StandardIO</string>
+	         <string>Background</string>
+            <!-- start agent during standard user sessions -->
+	         <string>user</string>
+	       </array>
+
+        <!-- The agent needs to run at all times -->
+        <key>KeepAlive</key>
+        <true/>
+
+        <!-- This prevents macOS from limiting the resource usage of the agent -->
+        <key>ProcessType</key>
+        <string>Interactive</string>
+
+        <!-- Increase the frequency of restarting the agent on failure, or post-update -->
+        <key>ThrottleInterval</key>
+        <integer>3</integer>
+
+        <!-- Wait for 10 minutes for the agent to shut down (the agent itself waits for tasks to complete) -->
+        <key>ExitTimeOut</key>
+        <integer>600</integer>
+
+        <key>StandardOutPath</key>
+        <string>#{logFile}</string>
+        <key>StandardErrorPath</key>
+        <string>#{logFile}</string>
+    </dict>
+</plist>"
+
+    File.open(plistFile, "w"){|f|f.write "#{plist}"}
+    
+    end
+  end
+
+
+  postflight do
+    if not File.exist?(configFile)
+      conf = "runner:
+  name: [[RUNNER_NAME]]
+  working_directory: \"#{workingDir}\"
+  cleanup_working_directory: true
+api:
+  auth_token: [[RESOURCE_CLASS_TOKEN]]"
+
+      File.open(configFile, "w"){|f| f.write "#{conf}"}
+    end
+
+  end
+
+
+  def caveats;  
+    "Logs: #{Dir.home}/Library/Logs/com.circleci.runner
+Config: #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml
+Documentation: https://circleci.com/docs/runner-overview/
+CircleCI Self-Hosted Runner Changelog: https://circleci.com/changelog/self-hosted-runner/
+Before Running:
+  To check application notarization run `$ spctl -a -vvv -t install \"$(brew --prefix)/bin/circleci-runner\"`
+
+  To accept the notarization headlessly run `$ sudo xattr -r -d com.apple.quarantine \"$(brew --prefix)/bin/circleci-runner\"`
+
+  Update the configration with your self-hosted runner token and runner name before starting
+
+  Enable and Start the CircleCI Runner LaunchAgent with `$ PLIST=#{Dir.home}/Library/LaunchAgents/com.circleci.runner.plist launchctl load $PLIST || (launchctl unload $PLIST && launchctl load $PLIST)`
+  Start CircleCI Runner manually with `$ circleci-runner machine --config #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml`
+  View the CircleCI Runner logs at #{Dir.home}/Library/Logs/com.circleci.runner/runner.log"
+  
+  end
+
+  zap trash:[
+    "#{configDir}/*",
+    "#{configDir}",
+    "#{plistFile}",
+    "#{logDir}/*",
+    "#{logDir}",
+    "#{workingDir}/*",
+  ]
+
+  uninstall launchctl: "com.circleci.runner"
+end

--- a/Casks/circleci-runner@3.0.24.rb
+++ b/Casks/circleci-runner@3.0.24.rb
@@ -1,0 +1,145 @@
+cask "circleci-runner" do
+  version "3.0.24"
+  name "circleci-runner"
+  desc "The self-hosted runner agent for CircleCI"
+  homepage "https://circleci.com/docs/2.0/runner-overview/"
+
+  intelSHA = "8ed5f51b8dac04b5a80d47a5ae6aa19eb5c77ecfa6e0af674f1f901349e0e3e5"
+  armSHA = "4efb794cf345153af870d2f61291ced6ece0c7eae46be296991753557931a046"
+  
+  if Hardware::CPU.intel? 
+    sha256 "#{intelSHA}"
+    url "https://circleci-binary-releases.s3.amazonaws.com/circleci-runner/#{version}/circleci-runner_darwin_amd64.tar.gz"
+    binary "circleci-runner"
+  else
+    sha256 "#{armSHA}"
+    url "https://circleci-binary-releases.s3.amazonaws.com/circleci-runner/#{version}/circleci-runner_darwin_arm64.tar.gz"
+    binary "circleci-runner"
+  end
+
+  configDir = "#{Dir.home}/Library/Preferences/com.circleci.runner"
+  configFile = "#{configDir}/config.yaml"
+  workingDir = "#{Dir.home}/Library/com.circleci.runner/workdir"
+  launchAgentDir = "#{Dir.home}/Library/LaunchAgents"
+  plistFile = "#{launchAgentDir}/com.circleci.runner.plist"
+  logDir = "#{Dir.home}/Library/Logs/com.circleci.runner"
+  logFile = "#{logDir}/runner.log"
+
+  prefix = ENV["HOMEBREW_PREFIX"]
+  service "#{Dir.home}/Library/LaunchAgents/com.circleci.runner.plist"
+
+  preflight do
+    # Create the necessary directories prior to installation
+    dirs = [configDir, launchAgentDir, logDir, workingDir]
+    dirs.each do |dir|
+      if not File.exist?(dir)
+        system_command 'mkdir', args: ['-p', dir]
+      end
+    end
+
+    if not File.exist?(plistFile)
+      plist = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+    <dict>
+        <key>Label</key>
+        <string>com.circleci.runner</string>
+
+        <key>Program</key>
+        <string>#{prefix}/bin/circleci-runner</string>
+
+        <key>ProgramArguments</key>
+        <array>
+            <string>#{prefix}/bin/circleci-runner</string>
+            <string>machine</string>
+            <string>--config</string>
+            <string>#{configFile}</string>
+        </array>
+
+        <key>RunAtLoad</key>
+        <true/>
+
+        	<key>LimitLoadToSessionType</key>
+	       <array>
+            <!-- start agent during GUI sessions -->
+	         <string>Aqua</string>
+            <!-- start agent during ssh sessions -->
+	         <string>StandardIO</string>
+	         <string>Background</string>
+            <!-- start agent during standard user sessions -->
+	         <string>user</string>
+	       </array>
+
+        <!-- The agent needs to run at all times -->
+        <key>KeepAlive</key>
+        <true/>
+
+        <!-- This prevents macOS from limiting the resource usage of the agent -->
+        <key>ProcessType</key>
+        <string>Interactive</string>
+
+        <!-- Increase the frequency of restarting the agent on failure, or post-update -->
+        <key>ThrottleInterval</key>
+        <integer>3</integer>
+
+        <!-- Wait for 10 minutes for the agent to shut down (the agent itself waits for tasks to complete) -->
+        <key>ExitTimeOut</key>
+        <integer>600</integer>
+
+        <key>StandardOutPath</key>
+        <string>#{logFile}</string>
+        <key>StandardErrorPath</key>
+        <string>#{logFile}</string>
+    </dict>
+</plist>"
+
+    File.open(plistFile, "w"){|f|f.write "#{plist}"}
+    
+    end
+  end
+
+
+  postflight do
+    if not File.exist?(configFile)
+      conf = "runner:
+  name: [[RUNNER_NAME]]
+  working_directory: \"#{workingDir}\"
+  cleanup_working_directory: true
+api:
+  auth_token: [[RESOURCE_CLASS_TOKEN]]"
+
+      File.open(configFile, "w"){|f| f.write "#{conf}"}
+    end
+
+  end
+
+
+  def caveats;  
+    "Logs: #{Dir.home}/Library/Logs/com.circleci.runner
+Config: #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml
+Documentation: https://circleci.com/docs/runner-overview/
+CircleCI Self-Hosted Runner Changelog: https://circleci.com/changelog/self-hosted-runner/
+Before Running:
+  To check application notarization run `$ spctl -a -vvv -t install \"$(brew --prefix)/bin/circleci-runner\"`
+
+  To accept the notarization headlessly run `$ sudo xattr -r -d com.apple.quarantine \"$(brew --prefix)/bin/circleci-runner\"`
+
+  Update the configration with your self-hosted runner token and runner name before starting
+
+  Enable and Start the CircleCI Runner LaunchAgent with `$ PLIST=#{Dir.home}/Library/LaunchAgents/com.circleci.runner.plist launchctl load $PLIST || (launchctl unload $PLIST && launchctl load $PLIST)`
+  Start CircleCI Runner manually with `$ circleci-runner machine --config #{Dir.home}/Library/Preferences/com.circleci.runner/config.yaml`
+  View the CircleCI Runner logs at #{Dir.home}/Library/Logs/com.circleci.runner/runner.log"
+  
+  end
+
+  zap trash:[
+    "#{configDir}/*",
+    "#{configDir}",
+    "#{plistFile}",
+    "#{logDir}/*",
+    "#{logDir}",
+    "#{workingDir}/*",
+  ]
+
+  uninstall launchctl: "com.circleci.runner"
+end


### PR DESCRIPTION
This PR adds in versioned formulas for the circleci-runner cask allow users to roll back to a previously released version of the macOS self hosted runner. 