### PR TITLE
[ONPREM-1946] Grant @circleci-internal-runner-bot co-ownership of Casks dir

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 * @CircleCI-Public/on-prem
 
 # @circleci-internal-runner-bot requires co-ownership so it can approve release PRs automatically
-/Casks/circleci-runner.rb @CircleCI-Public/on-prem @circleci-internal-runner-bot
+/Casks/ @CircleCI-Public/on-prem @circleci-internal-runner-bot


### PR DESCRIPTION
After introducing versioned formulas in PR #94, this broke our release automation since @circleci-internal-runner-bot also requires ownership of the versioned formulas in order to have sufficient permissions to fully approve the PR.