### PR TITLE
specify only runner casks owned by onprem

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 * @CircleCI-Public/on-prem
 
 # @circleci-internal-runner-bot requires co-ownership so it can approve release PRs automatically
-/Casks/ @CircleCI-Public/on-prem @circleci-internal-runner-bot
+/Casks/circleci-runner.rb* @CircleCI-Public/on-prem @circleci-internal-runner-bot


### PR DESCRIPTION
A follow up to the PR fixing ownership permissions. This avoids the On-Prem team implying they own any future casks provided by CircleCI. 