### PR TITLE
correct hashes from previous partial release

### DIFF
--- a/Casks/circleci-runner.rb
+++ b/Casks/circleci-runner.rb
@@ -4,8 +4,8 @@ cask "circleci-runner" do
   desc "The self-hosted runner agent for CircleCI"
   homepage "https://circleci.com/docs/2.0/runner-overview/"
 
-  intelSHA = "6b32d3fbe2dbb8acf8a9e82edc40a3a558214107c9fb2234814e5d3d5f24c331"
-  armSHA = "e333674a1a4eaa759265be146171ad940c12d80f53552c9cd6f4190144fb33ea"
+  intelSHA = "435b7dd4694840c2c9bf5fa044df6b0be65a26af4481b8cb142ca0fc0e28d798"
+  armSHA = "b4db25f4465a829c1f5fd28b2643d2510b5ab1368460e215ac08dbf19bf2a231"
   
   if Hardware::CPU.intel? 
     sha256 "#{intelSHA}"

--- a/Casks/circleci-runner@3.1.4.rb
+++ b/Casks/circleci-runner@3.1.4.rb
@@ -4,8 +4,8 @@ cask "circleci-runner@3.1.4" do
   desc "The self-hosted runner agent for CircleCI"
   homepage "https://circleci.com/docs/2.0/runner-overview/"
 
-  intelSHA = "6b32d3fbe2dbb8acf8a9e82edc40a3a558214107c9fb2234814e5d3d5f24c331"
-  armSHA = "e333674a1a4eaa759265be146171ad940c12d80f53552c9cd6f4190144fb33ea"
+  intelSHA = "435b7dd4694840c2c9bf5fa044df6b0be65a26af4481b8cb142ca0fc0e28d798"
+  armSHA = "b4db25f4465a829c1f5fd28b2643d2510b5ab1368460e215ac08dbf19bf2a231"
   
   if Hardware::CPU.intel? 
     sha256 "#{intelSHA}"


### PR DESCRIPTION
The release problems last week caused the incorrect hash to be released for cirlceci-runner. I've verified with the tarballs in S3, the S3 manifest, and our release pipeline that the current tarball in S3 matches with the release.

I've manually updated the 3.1.4 formula as well as the current formula to resolve the hash difference. 